### PR TITLE
Corrected Navigation3DAgent script

### DIFF
--- a/tutorials/navigation/navigation_using_navigationagents.rst
+++ b/tutorials/navigation/navigation_using_navigationagents.rst
@@ -164,7 +164,7 @@ This script adds basic navigation movement to a Node3D with a NavigationAgent3D 
 
     func _physics_process(delta):
 
-        movement_delta = move_speed * delta
+        movement_delta = movement_speed * delta
         var next_path_position : Vector3 = navigation_agent.get_next_location()
         var current_agent_position : Vector3 = global_transform.origin
         var new_velocity : Vector3 = (next_path_position - current_agent_position).normalized() * movement_delta
@@ -193,9 +193,10 @@ This script adds basic navigation movement to a CharacterBody3D with a Navigatio
 
     func _physics_process(delta):
 
+        movement_delta = movement_speed * delta
         var next_path_position : Vector3 = navigation_agent.get_next_location()
         var current_agent_position : Vector3 = global_transform.origin
-        var new_velocity : Vector3 = (next_path_position - current_agent_position).normalized() * movement_speed
+        var new_velocity : Vector3 = (next_path_position - current_agent_position).normalized() * movement_delta
         navigation_agent.set_velocity(new_velocity)
 
     func _on_NavigationAgent3D_velocity_computed(safe_velocity : Vector3):


### PR DESCRIPTION
Navigation3DAgent script snippet now shows velocity calculated as 'meters per second' rather than 'meters per frame'. "move_speed" has been changed to "movement_speed" for consistency.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
